### PR TITLE
Fix line break in arrow function

### DIFF
--- a/r.js
+++ b/r.js
@@ -67,8 +67,7 @@
       root.insertAdjacentHTML('afterBegin', str);
     }
 
-    Object.entries(handlers).forEach(([hid,nodeHandlers]) 
-      => addHandlersToMarkedInsertionPoint({hid,nodeHandlers}));
+    Object.entries(handlers).forEach(([hid,nodeHandlers]) => addHandlersToMarkedInsertionPoint({hid,nodeHandlers}));
   }
 
   function join (rs) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Line_breaks

This was causing an unexpected token error. 

I also noticed that the `1.2.0` release broke the `TodoMVC example` ([see issue here](https://github.com/dosyago-coder-0/rvanillatodo/issues/5)). I think this is a good time to think about adding tests. 